### PR TITLE
Redesign bookmarks page as Reading Log (Design A)

### DIFF
--- a/bookmarks/index.html
+++ b/bookmarks/index.html
@@ -50,12 +50,9 @@
         <!-- Main Content Area -->
         <main class="main-content">
             <section class="bookmarks-section">
-                <div id="filter-container" class="filter-container" style="display: none;">
-                    <span id="filter-tag" class="filter-tag-text"></span>
-                    <span class="filter-tooltip">Clear filter</span>
-                </div>
+                <div id="bookmarks-header" class="bk-header"></div>
                 <div id="bookmarks-container">
-                    <div class="loading">Loading bookmarks...</div>
+                    <div class="bk-loading">Loading bookmarks…</div>
                 </div>
             </section>
         </main>

--- a/css/bookmarks.css
+++ b/css/bookmarks.css
@@ -2,263 +2,250 @@
     margin-top: 40px;
 }
 
-.bookmark-item {
-    display: grid;
-    grid-template-columns: 150px 0.9fr 110px;
-    gap: 6px;
-    align-items: baseline;
-    padding: 8px 0;
-    border-bottom: 1px solid #e5e5e5;
-    margin-bottom: 8px;
-    padding-bottom: 16px;
+/* ── Header ─────────────────────────────────────── */
+.bk-header {
+    margin-bottom: 36px;
 }
 
-.bookmark-item:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
+.bk-heading {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
+    font-weight: 400;
+    letter-spacing: -0.03em;
+    color: #1a1a1a;
+    line-height: 1.1;
+    margin: 0;
 }
 
-.bookmark-link {
-    font-size: clamp(0.75rem, 1.2vw + 0.4rem, 0.9rem);
-    color: rgb(115, 115, 115);
-    font-weight: 500;
-    font-family: 'Courier New', 'Monaco', 'Menlo', 'Consolas', monospace;
-    position: relative;
+.bk-sub {
+    font-size: 0.82rem;
+    color: #737373;
+    margin-top: 6px;
+    line-height: 1.5;
+    max-width: 520px;
 }
 
-.bookmark-link a {
-    color: rgb(115, 115, 115);
-    text-decoration: none;
-    transition: color 0.3s ease;
-}
-
-.bookmark-link a:hover {
-    color: var(--main-text-color);
-}
-
-/* URL Tooltip */
-.url-tooltip {
-    position: absolute;
-    bottom: 100%;
-    left: 0;
-    background-color: #333;
-    color: #fff;
-    padding: 6px 10px;
-    border-radius: 6px;
-    font-size: 0.85rem;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s ease;
-    margin-bottom: 5px;
-    z-index: 1000;
-}
-
-.bookmark-link:hover .url-tooltip {
-    opacity: 1;
-}
-
-.bookmark-title {
-    font-size: clamp(0.875rem, 1.5vw + 0.5rem, 1rem);
-}
-
-.bookmark-title a {
-    font-size: clamp(0.85rem, 1.4vw + 0.5rem, 0.97rem);
-    color: var(--main-text-color);
-    text-decoration: none;
-    font-weight: 500;
-    transition: background-color 0.3s ease, color 0.3s ease;
-    padding: 6px 12px;
-    border-radius: 8px;
-    display: inline-block;
-}
-
-.bookmark-title a:hover {
-    background-color: rgba(128, 128, 128, 0.25);
-}
-
-.bookmark-tag {
-    font-size: clamp(0.75rem, 1.2vw + 0.4rem, 0.9rem);
-    color: rgb(115, 115, 115);
-    text-align: right;
-    font-weight: 500;
-}
-
-.loading {
-    text-align: center;
-    padding: 3rem;
-    color: var(--text-secondary, #666);
-}
-
-.error {
-    text-align: center;
-    padding: 3rem;
-    color: var(--error-color, #d32f2f);
-}
-
-.no-bookmarks {
-    text-align: center;
-    padding: 3rem;
-    color: var(--text-secondary, #666);
-}
-
-/* Dark mode adjustments */
-body.dark-mode .bookmark-link a {
-    color: rgb(163, 163, 163);
-}
-
-body.dark-mode .bookmark-link a:hover {
-    color: rgb(163, 163, 163);
-}
-
-body.dark-mode .url-tooltip {
-    background-color: #555;
-}
-
-body.dark-mode .bookmark-title a {
-    color: rgb(163, 163, 163);
-}
-
-body.dark-mode .bookmark-title a:hover {
-    background-color: rgba(255, 255, 255, 0.15);
-}
-
-body.dark-mode .bookmark-item {
-    border-bottom-color: #333;
-}
-
-/* Tag Filter Styles */
-.filter-container {
+.bk-counts {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto 30px auto;
-    padding: 0 16px;
-    background-color: #f5f5f5;
-    border-radius: 8px;
-    border: 1px solid #e0e0e0;
-    width: 208px;
-    height: 36px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    position: relative;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-top: 16px;
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.65rem;
+    color: #737373;
+    letter-spacing: 0.06em;
 }
 
-.filter-container:hover {
-    background-color: #e8e8e8;
-    border-color: #d0d0d0;
-}
-
-body.dark-mode .filter-container {
-    background-color: #2a2a2a;
-    border-color: #404040;
-}
-
-body.dark-mode .filter-container:hover {
-    background-color: #353535;
-    border-color: #505050;
-}
-
-/* Custom Tooltip */
-.filter-tooltip {
-    position: absolute;
-    bottom: -32px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #333;
-    color: #fff;
-    padding: 6px 12px;
-    border-radius: 6px;
-    font-size: 0.85rem;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.1s ease;
-}
-
-.filter-container:hover .filter-tooltip {
-    opacity: 1;
-}
-
-body.dark-mode .filter-tooltip {
-    background-color: #555;
-}
-
-.filter-tag-text {
-    font-size: clamp(0.875rem, 1.5vw + 0.5rem, 1rem);
+.bk-counts b {
+    color: #1a1a1a;
     font-weight: 500;
-    color: var(--main-text-color);
+    margin-right: 3px;
 }
 
-body.dark-mode .filter-tag-text {
-    color: rgb(163, 163, 163);
+.bk-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 20px;
 }
 
-/* Make tags clickable */
-.bookmark-tag {
+.bk-chip {
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.62rem;
+    color: #737373;
+    padding: 4px 10px;
+    border: 1px solid #d5d5d5;
+    border-radius: 999px;
     cursor: pointer;
-    transition: opacity 0.2s ease;
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    letter-spacing: 0.02em;
 }
 
-.bookmark-tag:hover {
-    opacity: 0.7;
+.bk-chip:hover {
+    border-color: #aaa;
+    color: #3a3a3a;
 }
 
-/* Mobile Layout */
+.bk-chip.on {
+    background: #1a1a1a;
+    color: #fff;
+    border-color: #1a1a1a;
+}
+
+/* ── Month groups ──────────────────────────────── */
+.bk-month {
+    margin-bottom: 8px;
+}
+
+.bk-month-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-top: 36px;
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 1rem;
+    font-weight: 400;
+    color: #1a1a1a;
+}
+
+.bk-month-count {
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.62rem;
+    color: #aaa;
+    letter-spacing: 0.04em;
+}
+
+/* ── Bookmark items ────────────────────────────── */
+.bk-item {
+    display: grid;
+    grid-template-columns: 52px 1fr auto;
+    gap: 16px;
+    padding: 12px 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    align-items: baseline;
+}
+
+.bk-item:last-child {
+    border-bottom: none;
+}
+
+.bk-item-date {
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.62rem;
+    color: #aaa;
+    padding-top: 2px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+}
+
+.bk-item-body {
+    min-width: 0;
+}
+
+.bk-item-title {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: #1a1a1a;
+    line-height: 1.3;
+}
+
+.bk-item-title a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s ease;
+}
+
+.bk-item-title a:hover {
+    border-bottom-color: #aaa;
+}
+
+.bk-item-desc {
+    font-size: 0.72rem;
+    color: #737373;
+    margin-top: 3px;
+    line-height: 1.4;
+}
+
+.bk-item-src {
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.62rem;
+    color: #aaa;
+    margin-top: 4px;
+    letter-spacing: 0.02em;
+}
+
+.bk-item-tag {
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.6rem;
+    color: #aaa;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    transition: color 0.15s ease;
+    white-space: nowrap;
+    padding-top: 2px;
+}
+
+.bk-item-tag:hover {
+    color: #555;
+}
+
+/* ── States ──────────────────────────────────────── */
+.bk-loading,
+.bk-empty,
+.bk-error {
+    text-align: center;
+    padding: 3rem 0;
+    font-size: 0.8rem;
+    color: #aaa;
+}
+
+/* ── Dark mode ──────────────────────────────────── */
+body.dark-mode .bk-heading {
+    color: #f5f5f5;
+}
+
+body.dark-mode .bk-counts b {
+    color: #e5e5e5;
+}
+
+body.dark-mode .bk-chip {
+    color: #737373;
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+body.dark-mode .bk-chip:hover {
+    border-color: rgba(255, 255, 255, 0.3);
+    color: #a3a3a3;
+}
+
+body.dark-mode .bk-chip.on {
+    background: #fff;
+    color: #000;
+    border-color: #fff;
+}
+
+body.dark-mode .bk-month-header {
+    color: #e5e5e5;
+    border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .bk-item {
+    border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+body.dark-mode .bk-item-title {
+    color: #f5f5f5;
+}
+
+body.dark-mode .bk-item-title a:hover {
+    border-bottom-color: #555;
+}
+
+body.dark-mode .bk-item-desc {
+    color: #737373;
+}
+
+body.dark-mode .bk-item-tag:hover {
+    color: #a3a3a3;
+}
+
+/* ── Mobile ─────────────────────────────────────── */
 @media (max-width: 768px) {
-    .bookmark-item {
+    .bk-item {
         grid-template-columns: 1fr;
-        gap: 2px;
-        padding: 12px 0;
-        margin-bottom: 12px;
-        padding-bottom: 16px;
-        border-bottom: 1px solid #e5e5e5;
+        gap: 3px;
+        padding: 14px 0;
     }
 
-    .bookmark-item:last-child {
-        border-bottom: none;
-        margin-bottom: 0;
-    }
-
-    .bookmark-link {
-        text-align: left;
-        font-size: clamp(0.8rem, 2vw + 0.4rem, 0.9rem);
-        margin-bottom: 4px;
-    }
-
-    .bookmark-title {
-        margin-bottom: 2px;
-        display: flex;
-        align-items: baseline;
-    }
-
-    .bookmark-title::before {
-        content: '•';
-        color: rgb(115, 115, 115);
-        font-size: 1.2rem;
-        margin-right: 8px;
-        flex-shrink: 0;
-    }
-
-    .bookmark-title a {
-        padding: 0;
-        font-size: clamp(0.9rem, 2.5vw + 0.5rem, 1rem);
-    }
-
-    .bookmark-tag {
+    .bk-item-date {
         display: none;
     }
 
-    .url-tooltip {
-        left: 0;
-        transform: none;
-    }
-
-    body.dark-mode .bookmark-title::before {
-        color: rgb(163, 163, 163);
-    }
-
-    body.dark-mode .bookmark-item {
-        border-bottom-color: #333;
+    .bk-item-tag {
+        display: none;
     }
 }

--- a/javascript/bookmarks.js
+++ b/javascript/bookmarks.js
@@ -1,23 +1,37 @@
 let allBookmarks = [];
 let currentFilter = null;
 
+function esc(str) {
+    return String(str ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 async function fetchBookmarks() {
     const container = document.getElementById('bookmarks-container');
-
     try {
         const response = await fetch('/data/bookmarks.json');
-        if (!response.ok) throw new Error('Failed to fetch bookmarks');
+        if (!response.ok) throw new Error('fetch failed');
 
         const bookmarks = await response.json();
 
         if (bookmarks.length === 0) {
-            container.innerHTML = '<div class="no-bookmarks">No bookmarks yet. Check back soon!</div>';
+            container.textContent = '';
+            const empty = document.createElement('div');
+            empty.className = 'bk-empty';
+            empty.textContent = 'No bookmarks yet. Check back soon!';
+            container.appendChild(empty);
             return;
         }
 
         allBookmarks = bookmarks.slice().sort((a, b) =>
             new Date(b.date || 0) - new Date(a.date || 0)
         );
+
+        renderHeader();
 
         const urlParams = new URLSearchParams(window.location.search);
         const tagFilter = urlParams.get('tag');
@@ -28,92 +42,219 @@ async function fetchBookmarks() {
         }
     } catch (error) {
         console.error('Error fetching bookmarks:', error);
-        container.innerHTML = '<div class="error">Failed to load bookmarks. Please try again later.</div>';
+        container.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'bk-error';
+        err.textContent = 'Failed to load bookmarks. Please try again later.';
+        container.appendChild(err);
     }
+}
+
+function getTagCounts() {
+    const counts = {};
+    allBookmarks.forEach(b => {
+        if (b.tag) {
+            const t = b.tag.toLowerCase();
+            counts[t] = (counts[t] || 0) + 1;
+        }
+    });
+    return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+}
+
+function renderHeader() {
+    const header = document.getElementById('bookmarks-header');
+    header.textContent = '';
+    const tags = getTagCounts();
+    const total = allBookmarks.length;
+    const earliest = allBookmarks.length
+        ? new Date(allBookmarks[allBookmarks.length - 1].date || 0).getFullYear()
+        : '—';
+
+    const heading = document.createElement('div');
+    heading.className = 'bk-heading';
+    heading.textContent = 'Bookmarks';
+
+    const sub = document.createElement('div');
+    sub.className = 'bk-sub';
+    sub.textContent = 'Articles and pages worth keeping. Updated as I find things.';
+
+    const counts = document.createElement('div');
+    counts.className = 'bk-counts';
+    counts.innerHTML =
+        `<span><b>${total}</b> links</span>` +
+        `<span><b>${tags.length}</b> tags</span>` +
+        `<span><b>since</b> ${esc(String(earliest))}</span>`;
+
+    const chipsRow = document.createElement('div');
+    chipsRow.className = 'bk-chips';
+
+    const makeChip = (tag, label) => {
+        const chip = document.createElement('span');
+        chip.className = 'bk-chip';
+        chip.dataset.tag = tag;
+        chip.textContent = label;
+        chip.addEventListener('click', () => {
+            if (!tag || (currentFilter && currentFilter === tag)) {
+                clearFilter();
+            } else {
+                filterByTag(tag);
+            }
+        });
+        return chip;
+    };
+
+    chipsRow.appendChild(makeChip('', 'all'));
+    tags.forEach(([tag, count]) => {
+        chipsRow.appendChild(makeChip(tag, `${tag} · ${count}`));
+    });
+
+    header.appendChild(heading);
+    header.appendChild(sub);
+    header.appendChild(counts);
+    header.appendChild(chipsRow);
+
+    updateChips();
+}
+
+function updateChips() {
+    document.querySelectorAll('.bk-chip').forEach(chip => {
+        const tag = chip.dataset.tag;
+        chip.classList.toggle('on', !tag ? !currentFilter : currentFilter === tag);
+    });
 }
 
 function renderBookmarks(bookmarks) {
     const container = document.getElementById('bookmarks-container');
+    container.textContent = '';
 
     if (bookmarks.length === 0) {
-        container.innerHTML = '<div class="no-bookmarks">No bookmarks found with this tag.</div>';
+        const empty = document.createElement('div');
+        empty.className = 'bk-empty';
+        empty.textContent = 'No bookmarks found with this tag.';
+        container.appendChild(empty);
         return;
     }
 
-    container.innerHTML = bookmarks.map(renderBookmarkRow).join('');
-
-    document.querySelectorAll('.bookmark-tag').forEach(tagElement => {
-        tagElement.style.cursor = 'pointer';
-        tagElement.addEventListener('click', function (e) {
-            e.preventDefault();
-            const tagText = this.textContent.replace('#', '').trim();
-            if (tagText) {
-                if (currentFilter && currentFilter.toLowerCase() === tagText.toLowerCase()) {
-                    clearFilter();
-                } else {
-                    filterByTag(tagText);
-                }
-            }
-        });
+    const groups = {};
+    const groupOrder = [];
+    bookmarks.forEach(b => {
+        const date = new Date(b.date || 0);
+        const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+        if (!groups[key]) {
+            groups[key] = {
+                label: date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),
+                items: []
+            };
+            groupOrder.push(key);
+        }
+        groups[key].items.push(b);
     });
+
+    groupOrder.forEach(key => {
+        const { label, items } = groups[key];
+
+        const monthDiv = document.createElement('div');
+        monthDiv.className = 'bk-month';
+
+        const monthHeader = document.createElement('div');
+        monthHeader.className = 'bk-month-header';
+
+        const monthName = document.createElement('span');
+        monthName.className = 'bk-month-name';
+        monthName.textContent = label;
+
+        const monthCount = document.createElement('span');
+        monthCount.className = 'bk-month-count';
+        monthCount.textContent = `· ${items.length} link${items.length !== 1 ? 's' : ''}`;
+
+        monthHeader.appendChild(monthName);
+        monthHeader.appendChild(monthCount);
+        monthDiv.appendChild(monthHeader);
+
+        items.forEach(b => {
+            monthDiv.appendChild(renderItem(b));
+        });
+
+        container.appendChild(monthDiv);
+    });
+}
+
+function renderItem(b) {
+    let host = b.url || '';
+    try { host = new URL(b.url).hostname.replace('www.', ''); } catch (e) {}
+
+    const dateStr = b.date
+        ? new Date(b.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+        : '—';
+
+    const item = document.createElement('div');
+    item.className = 'bk-item';
+
+    const dateEl = document.createElement('span');
+    dateEl.className = 'bk-item-date';
+    dateEl.textContent = dateStr;
+
+    const body = document.createElement('div');
+    body.className = 'bk-item-body';
+
+    const titleDiv = document.createElement('div');
+    titleDiv.className = 'bk-item-title';
+    const link = document.createElement('a');
+    link.href = b.url || '#';
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = b.title || '(untitled)';
+    titleDiv.appendChild(link);
+    body.appendChild(titleDiv);
+
+    if (b.description) {
+        const desc = document.createElement('div');
+        desc.className = 'bk-item-desc';
+        desc.textContent = b.description;
+        body.appendChild(desc);
+    }
+
+    const src = document.createElement('div');
+    src.className = 'bk-item-src';
+    src.textContent = host;
+    body.appendChild(src);
+
+    const tagEl = document.createElement('span');
+    if (b.tag) {
+        tagEl.className = 'bk-item-tag';
+        tagEl.dataset.tag = b.tag.toLowerCase();
+        tagEl.textContent = b.tag;
+        tagEl.addEventListener('click', () => {
+            const tag = tagEl.dataset.tag;
+            currentFilter === tag ? clearFilter() : filterByTag(tag);
+        });
+    }
+
+    item.appendChild(dateEl);
+    item.appendChild(body);
+    item.appendChild(tagEl);
+
+    return item;
 }
 
 function filterByTag(tag) {
     currentFilter = tag;
-
-    const filterContainer = document.getElementById('filter-container');
-    const filterTagText = document.getElementById('filter-tag');
-    filterContainer.style.display = 'flex';
-    filterTagText.textContent = '#' + tag;
-
-    const filtered = allBookmarks.filter(b =>
+    updateChips();
+    renderBookmarks(allBookmarks.filter(b =>
         b.tag && b.tag.toLowerCase() === tag.toLowerCase()
-    );
-
+    ));
     const url = new URL(window.location);
     url.searchParams.set('tag', tag);
     window.history.pushState({}, '', url);
-
-    renderBookmarks(filtered);
 }
 
 function clearFilter() {
     currentFilter = null;
-
-    const filterContainer = document.getElementById('filter-container');
-    filterContainer.style.display = 'none';
-
+    updateChips();
+    renderBookmarks(allBookmarks);
     const url = new URL(window.location);
     url.searchParams.delete('tag');
     window.history.pushState({}, '', url);
-
-    renderBookmarks(allBookmarks);
 }
 
-function renderBookmarkRow(bookmark) {
-    let displayUrl = bookmark.url;
-    try {
-        const urlObj = new URL(bookmark.url);
-        displayUrl = urlObj.hostname.replace('www.', '');
-    } catch (e) {
-        displayUrl = bookmark.url;
-    }
-
-    const tagDisplay = bookmark.tag ? `#${bookmark.tag}` : '';
-
-    return `
-        <div class="bookmark-item">
-            <div class="bookmark-link">
-                <a href="${bookmark.url}" target="_blank" rel="noopener noreferrer">${displayUrl}</a>
-                <span class="url-tooltip">${bookmark.url}</span>
-            </div>
-            <div class="bookmark-title"><a href="${bookmark.url}" target="_blank" rel="noopener noreferrer">${bookmark.title}</a></div>
-            <div class="bookmark-tag">${tagDisplay}</div>
-        </div>
-    `;
-}
-
-document.addEventListener('DOMContentLoaded', function () {
-    fetchBookmarks();
-    document.getElementById('filter-container').addEventListener('click', clearFilter);
-});
+document.addEventListener('DOMContentLoaded', fetchBookmarks);


### PR DESCRIPTION
- Replace 3-column sparse grid with month-grouped Reading Log layout
- Add header with total count, tag count, and "since" year
- Tag filter chips at top replace the old inline filter-container
- Entries show date / title / source / tag in a clean 3-col grid
- Group bookmarks by month with link count in section header
- All DOM rendering uses textContent / createElement (no innerHTML XSS risk)
- Support both light and dark mode
- Keep existing filterByTag / clearFilter / URL param logic intact