### PR TITLE
Fix music player not working on mobile (iOS)

### DIFF
--- a/javascript/now-playing.js
+++ b/javascript/now-playing.js
@@ -114,7 +114,8 @@
                 fs:              0,
                 iv_load_policy:  3,
                 modestbranding:  1,
-                rel:             0
+                rel:             0,
+                playsinline:     1
             },
             events: {
                 onReady: function () {


### PR DESCRIPTION
Add playsinline: 1 to YouTube IFrame playerVars so iOS Safari plays
inline instead of attempting fullscreen, which blocked programmatic
playVideo() calls from the external play button.

https://claude.ai/code/session_0194m9peGMA1EUxZpPWNjTH3